### PR TITLE
Support for function calls

### DIFF
--- a/include/abc/ast/Call.h
+++ b/include/abc/ast/Call.h
@@ -67,6 +67,10 @@ class Call : public AbstractExpression {
   /// \return Vector of (references to) all non-null arguments
   std::vector<std::reference_wrapper<AbstractExpression>> getArguments();
 
+  /// Create a Call node from a nlohmann::json representation of this node.
+  /// \return unique_ptr to a new Call node
+  static std::unique_ptr<Call> fromJson(nlohmann::json j);
+
   ///////////////////////////////////////////////
   ////////// AbstractNode Interface /////////////
   ///////////////////////////////////////////////

--- a/include/abc/ast/Function.h
+++ b/include/abc/ast/Function.h
@@ -100,6 +100,10 @@ class Function : public AbstractStatement {
   /// \throws std::runtime_error if no body exists
   Block &getBody();
 
+  /// Create a Function node from a nlohmann::json representation of this node.
+  /// \return unique_ptr to a new Function node
+  static std::unique_ptr<Function> fromJson(nlohmann::json j);
+
   ///////////////////////////////////////////////
   ////////// AbstractNode Interface /////////////
   ///////////////////////////////////////////////

--- a/include/abc/ast/FunctionParameter.h
+++ b/include/abc/ast/FunctionParameter.h
@@ -58,6 +58,10 @@ class FunctionParameter : public AbstractTarget {
 
   [[nodiscard]] const Datatype &getParameterType() const;
 
+  /// Create a FunctionParameter node from a nlohmann::json representation of this node.
+  /// \return unique_ptr to a new For node
+  static std::unique_ptr<FunctionParameter> fromJson(nlohmann::json j);
+
   ///////////////////////////////////////////////
   ////////// AbstractNode Interface /////////////
   ///////////////////////////////////////////////

--- a/include/abc/ast_utilities/AbcAstToMlirVisitor.h
+++ b/include/abc/ast_utilities/AbcAstToMlirVisitor.h
@@ -18,7 +18,6 @@ typedef Visitor<SpecialAbcAstToMlirVisitor, PlainVisitor> AbcAstToMlirVisitor;
 class SpecialAbcAstToMlirVisitor : public PlainVisitor {
  private:
   mlir::OpBuilder builder;
-  mlir::ModuleOp module;
   mlir::Block *block;
 
   void add_op(mlir::Operation *op);
@@ -31,7 +30,6 @@ class SpecialAbcAstToMlirVisitor : public PlainVisitor {
 
 #include "abc/ast_utilities/warning_suggestOverride_prologue.h"
 
-  mlir::ModuleOp getModule();
   mlir::Block *getBlockPtr();
 
   void visit(AbstractExpression &expr);

--- a/include/abc/ast_utilities/NodeUtils.h
+++ b/include/abc/ast_utilities/NodeUtils.h
@@ -8,7 +8,8 @@
 
 enum NodeType : unsigned char {
   // AbstractStatement
-  NodeTypeAssignment = 0, NodeTypeBlock, NodeTypeFor, NodeTypeIf, NodeTypeReturn, NodeTypeVariableDeclaration,
+  NodeTypeAssignment = 0, NodeTypeBlock, NodeTypeFunction, NodeTypeFor, NodeTypeIf, NodeTypeReturn,
+  NodeTypeVariableDeclaration,
 
   // AbstractExpression -> AbstractTarget
   NodeTypeFunctionParameter, NodeTypeIndexAccess, NodeTypeVariable,

--- a/python/examples/example_basic.py
+++ b/python/examples/example_basic.py
@@ -1,0 +1,16 @@
+from pyabc import *
+import logging
+
+p = ABCProgram(logging.DEBUG)
+
+with ABCContext(p, logging.DEBUG):
+    def main():
+        a = 1.0
+        if a * a < a:
+            return 20
+
+
+        s = 0
+        for i in range(10):
+            s += i
+        return s

--- a/python/examples/example_fn_call.py
+++ b/python/examples/example_fn_call.py
@@ -1,0 +1,11 @@
+from pyabc import *
+import logging
+
+p = ABCProgram(logging.DEBUG)
+
+with ABCContext(p, logging.DEBUG):
+    def add(i, j):
+        return i + j
+
+    def main(a):
+        return add(a, 2)

--- a/python/pyabc/ABCContext.py
+++ b/python/pyabc/ABCContext.py
@@ -3,10 +3,16 @@ import logging
 
 from ast import *
 from inspect import getsource
-from sys import _getframe
+from sys import _getframe, exit, version_info
 
 from .ABCVisitor import ABCVisitor
 from .ABCProgram import ABCProgram
+
+# The Python AST changed after 3.6, it might already work in 3.7, but this is not tested.
+MIN_PYTHON = (3, 9)
+
+if version_info < MIN_PYTHON:
+    exit("Currently, the frontend only supports Python %s.%s or later.\n" % MIN_PYTHON)
 
 class ABCContext():
     """
@@ -34,9 +40,10 @@ class ABCContext():
             if isinstance(item, With) and item.lineno == parent_frame.f_lineno - parent_frame.f_code.co_firstlineno + 1:
                 logging.debug(f"Start parsing With block at line {item.lineno}")
 
+                self.prog.set_curr_blocks(item.body)
                 for block in item.body:
                     ABCVisitor(self.prog, self.log_level).visit(block)
                 break
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+        self.prog.compile()

--- a/python/pyabc/ABCJsonAstBuilder.py
+++ b/python/pyabc/ABCJsonAstBuilder.py
@@ -86,6 +86,9 @@ class ABCJsonAstBuilder:
         d.update(content)
         return d
 
+    def _make_arguments(self, arguments):
+        return {"arguments": arguments}
+
     def _make_body(self, body):
         return {"body": body}
 
@@ -116,6 +119,12 @@ class ABCJsonAstBuilder:
     def _make_op(self, op):
         return {"operator": op}
 
+    def _make_params(self, params):
+        return {"parameters": params}
+
+    def _make_param_type(self, t):
+        return {"parameter_type": t}
+
     def _make_right(self, right):
         return {"right": right}
 
@@ -124,6 +133,9 @@ class ABCJsonAstBuilder:
 
     def _make_expressions(self, stmts):
         return {"expressions": stmts}
+
+    def _make_return_type(self, stmt):
+        return {"return_type": stmt}
 
     def _make_target(self, target):
         return {"target": target}
@@ -183,6 +195,20 @@ class ABCJsonAstBuilder:
 
         return self._make_abc_node("Block", self._make_stmts(stmts))
 
+    def make_call(self, identifier : str, arguments : list) -> dict:
+        """
+        Create a dictionary corresponding to an ABC Call node for the given function and arguments
+
+        :param identifier: Name of the function
+        :param arguments: List of JSON-equivalent dictionaries of ABC function parameters
+        :return: JSON-equivalent dictionary for an ABC Call
+        """
+
+        d = self._make_identifier(identifier)
+        d.update(self._make_arguments(arguments))
+
+        return self._make_abc_node("Call", d)
+
     def make_expression_list(self, exprs : list) -> dict:
         """
         Create a dictionary corresponding to an ABC ExpressionList node when exported in JSON
@@ -192,6 +218,38 @@ class ABCJsonAstBuilder:
         """
 
         return self._make_abc_node("ExpressionList", self._make_expressions(exprs))
+
+    def make_function(self, identifier : str, return_type : str, params : dict, body : dict) -> dict:
+        """
+        Create a dictionary corresponding to an ABC Function node when exported in JSON
+
+        :param identifier: Name of the function
+        :param return_type: Return type of the function
+        :param params: Parameters of the function (dict with list of FunctionParameters)
+        :param body: Function body
+        :return: JSON-equivalent dictionary for an Function node
+        """
+
+        d = self._make_identifier(identifier)
+        d.update(self._make_return_type(return_type))
+        d.update(self._make_params(params))
+        d.update(self._make_body(body))
+
+        return self._make_abc_node("Function", d)
+
+    def make_function_param(self, identifier : str, param_type : str):
+        """
+        Create a dictionary corresponding to an ABC FunctionParameter node when exported in JSON
+
+        :param identifier: Name of the parameter
+        :param param_type: Type of the parameter
+        :return:
+        """
+
+        d = self._make_identifier(identifier)
+        d.update(self._make_param_type(param_type))
+
+        return self._make_abc_node("FunctionParameter", d)
 
     def make_for(self, initializer : dict, condition : dict, update : dict, body : dict) -> dict:
         """

--- a/src/ast/Call.cpp
+++ b/src/ast/Call.cpp
@@ -1,5 +1,6 @@
 #include "abc/ast/Call.h"
 #include "abc/ast_utilities/IVisitor.h"
+#include "abc/ast_parser/Parser.h"
 
 /// Convenience typedef for conciseness
 typedef std::unique_ptr<AbstractExpression> exprPtr;
@@ -116,6 +117,16 @@ nlohmann::json Call::toJson() const {
                       {"arguments", argsJSON}
   };
   return j;
+}
+
+std::unique_ptr<Call> Call::fromJson(nlohmann::json j) {
+  auto identifier = j["identifier"].get<std::string>();
+  std::vector<std::unique_ptr<AbstractExpression>> args;
+  for (auto arg : j["arguments"]) {
+    args.emplace_back(Parser::parseJsonExpression(arg));
+  }
+
+  return std::make_unique<Call>(identifier, std::move(args));
 }
 
 std::string Call::toString(bool printChildren) const {

--- a/src/ast/FunctionParameter.cpp
+++ b/src/ast/FunctionParameter.cpp
@@ -81,6 +81,13 @@ nlohmann::json FunctionParameter::toJson() const {
   return j;
 }
 
+std::unique_ptr<FunctionParameter> FunctionParameter::fromJson(nlohmann::json j) {
+  auto param_type = Datatype(j["parameter_type"].get<std::string>());
+  auto identifier = j["identifier"].get<std::string>();
+
+  return std::make_unique<FunctionParameter>(param_type, identifier);
+}
+
 std::string FunctionParameter::toString(bool printChildren) const {
   return AbstractNode::toStringHelper(printChildren, {getParameterType().toString(), getIdentifier()});
 }

--- a/src/ast_parser/Parser.cpp
+++ b/src/ast_parser/Parser.cpp
@@ -94,7 +94,7 @@ std::unique_ptr<AbstractTarget> Parser::parseJsonTarget(json j) {
     case NodeTypeIndexAccess:
       return IndexAccess::fromJson(j);
     case NodeTypeFunctionParameter:
-      throw stork::runtime_error("Unsupported AbstractTarget: '" + type + "' is not yet implemented.");
+      return FunctionParameter::fromJson(j);
     default:
       throw stork::runtime_error("Unsupported type: '" + type + "' is not an AbstractTarget.");
   }
@@ -106,6 +106,8 @@ std::unique_ptr<AbstractExpression> Parser::parseJsonExpression(json j) {
   switch (NodeUtils::stringToEnum(type)) {
     case NodeTypeBinaryExpression:
       return BinaryExpression::fromJson(j);
+    case NodeTypeCall:
+      return Call::fromJson(j);
     case NodeTypeExpressionList:
       return ExpressionList::fromJson(j);
     case NodeTypeLiteralBool:
@@ -122,7 +124,6 @@ std::unique_ptr<AbstractExpression> Parser::parseJsonExpression(json j) {
       return LiteralString::fromJson(j);
     case NodeTypeOperatorExpression:
     case NodeTypeUnaryExpression:
-    case NodeTypeCall:
     case NodeTypeTernaryOperator:
       throw stork::runtime_error("Unsupported AbstractExpression: '" + type + "' is not yet implemented.");
     default:
@@ -150,6 +151,8 @@ std::unique_ptr<AbstractStatement> Parser::parseJsonStatement(json j) {
       return Return::fromJson(j);
     case NodeTypeVariableDeclaration:
       return VariableDeclaration::fromJson(j);
+    case NodeTypeFunction:
+      return Function::fromJson(j);
     case NodeTypeFor:
       return For::fromJson(j);
     case NodeTypeIf:

--- a/src/ast_utilities/NodeUtils.cpp
+++ b/src/ast_utilities/NodeUtils.cpp
@@ -6,6 +6,7 @@ std::string NodeUtils::enumToString(const NodeType type) {
   std::unordered_map<NodeType, std::string> typeToString = {
       {NodeType::NodeTypeAssignment, "Assignment"},
       {NodeType::NodeTypeBlock, "Block"},
+      {NodeType::NodeTypeFunction, "Function"},
       {NodeType::NodeTypeFor, "For"},
       {NodeType::NodeTypeIf, "If"},
       {NodeType::NodeTypeReturn, "Return"},
@@ -43,6 +44,7 @@ bool NodeUtils::isAbstractStatement(const std::string s) {
   switch (NodeUtils::stringToEnum(s)) {
     case NodeTypeAssignment:
     case NodeTypeBlock:
+    case NodeTypeFunction:
     case NodeTypeFor:
     case NodeTypeIf:
     case NodeTypeReturn:


### PR DESCRIPTION
This PR adds support for function calls to the Python frontend (and some bug fixes).

See the [readme](https://github.com/MarbleHE/ABC/tree/mh/mlir-frontend-improvements/python/README.md) for more information. An example Python frontend snippet is in [here](https://github.com/MarbleHE/ABC/tree/mh/mlir-frontend-improvements/python/examples/example_fn_call.py).

Type annotations are ignored at the moment, all function parameters get the type "void".